### PR TITLE
easier version updating.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 # bsp-layout
 
-VERSION = 0.0.9
-
 PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 SRCPREFIX = ${PREFIX}/lib
@@ -21,11 +19,11 @@ install:
 	mkdir -p ${BINARY_PATH} ${SRC_PATH} ${MAN_PATH}
 	cp -rf src/* ${SRC_PATH}/ # Source files
 	cp src/layout.sh layout.sh.tmp
-	sed "s|{{VERSION}}|${VERSION}|g" layout.sh.tmp > ${SRC_PATH}/layout.sh # Update version
+	bash update_version.sh ${SRC_PATH}
 	cp -f ${SRC_PATH}/layout.sh layout.sh.tmp
 	sed "s|{{SOURCE_PATH}}|${SRC_PATH}|g" layout.sh.tmp > ${SRC_PATH}/layout.sh # Update source path
 	rm layout.sh.tmp
-	sed "s|{{VERSION}}|${VERSION}|g" bsp-layout.1 > ${MANPAGE} # Manpage
+	bash update_version.sh ${MANPAGE}
 	chmod 644 ${MANPAGE} # Manpage permission
 	chmod 755 ${SRC_PATH}/layouts/*.sh
 	chmod 755 ${SRC_PATH}/layout.sh

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+update_string="Updating version for";
+
+if [[ "$1" == *bsp-layout.1 ]]; then
+  echo "$update_string manpage"
+  sed "s|{{VERSION}}|$(git describe --tags --abbrev=0)|g" bsp-layout.1 > "$1"
+else
+  echo "$update_string main script"
+  sed "s|{{VERSION}}|$(git describe --tags --abbrev=0)|g" layout.sh.tmp > "$1"/layout.sh
+fi


### PR DESCRIPTION
Updating the version using git tags. With this way, we could even use `git describe --tags --dirty` for a test build and use `git describe --tags --abbrev=0` for stable install. Was unable to do that though.