### PR TITLE
Add option to use desktop id instead of name

### DIFF
--- a/example.layoutrc
+++ b/example.layoutrc
@@ -5,3 +5,5 @@ TALL_RATIO=0.6;
 # Wide layout config
 WIDE_RATIO=0.6;
 
+# Use desktop names(1) or ids(0)
+USE_NAMES=1;

--- a/src/layout.sh
+++ b/src/layout.sh
@@ -45,7 +45,10 @@ run_layout() {
 }
 
 get_layout() {
-  local layout=$(get_desktop_options "$1" | valueof layout);
+  # Set desktop to currently focused desktop if option is not specified
+  local desktop="${1:-`get_focused_desktop`}";
+
+  local layout=$(get_desktop_options "$desktop" | valueof layout);
   echo "${layout:-"-"}";
 }
 

--- a/src/layout.sh
+++ b/src/layout.sh
@@ -32,7 +32,7 @@ remove_listener() {
 get_layout_file() {
   local layout_file="$LAYOUTS/$1.sh"; shift;
   # GUARD: Check if layout exists
-  [[ ! -f $layout_file ]] && echo "Layout does not exist" && exit 1;
+  [[ ! -f $layout_file ]] && echo "Layout [$layout_file] does not exist" && exit 1;
   echo "$layout_file";
 }
 
@@ -155,6 +155,7 @@ start_listener() {
 }
 
 once_layout() {
+  if (echo -e "$BSP_DEFAULT_LAYOUTS" | grep "^$@$"); then exit 0; fi
   run_layout "$@";
   run_layout "$@";
 }

--- a/src/utils/config.sh
+++ b/src/utils/config.sh
@@ -4,5 +4,6 @@ CONFIG_DIR="$XDG_CONF/bsp-layout";
 # Default config
 export TALL_RATIO=0.6;
 export WIDE_RATIO=0.6;
+export USE_NAMES=1;
 
 source "$CONFIG_DIR/layoutrc" 2> /dev/null || true;

--- a/src/utils/desktop.sh
+++ b/src/utils/desktop.sh
@@ -1,3 +1,6 @@
-get_focused_desktop() { bspc query -D -d 'focused' --names; }
-get_desktop_name_from_id() { bspc query -D -d "$1" --names; }
+source "$ROOT/utils/config.sh";
+names="--names"
+[[ $USE_NAMES -eq 0 ]] && names="";
+get_focused_desktop() { bspc query -D -d 'focused' $names; }
+get_desktop_name_from_id() { bspc query -D -d "$1" $names; }
 


### PR DESCRIPTION
I use [btops](https://github.com/ivanmilov/btops) for dynamic workspace naming and for some names it is not possible to create the DESKTOP_STATE file (e.g. '2 ') and desktop names are not constant anymore.
I added an option to use desktop ids instead of names.