### PR TITLE
Replace cycle with previous and next in layout switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,23 +165,36 @@ This will apply the layout on the current set of nodes on that workspace but new
 bsp-layout once tall
 ```
 
-* Cycle through layouts
-Cycle through all (or a custom list of) layouts.
+* Go back through layouts
+Go back through all (or a custom list of) layouts.
 ```bash
-# Cycle through all layouts
-bsp-layout cycle
+# Switch to previous layout
+bsp-layout previous
 
-# Or to cycle through a custom list of layouts
-bsp-layout cycle --layouts tall,monocle,wide
+# Or to go back through a custom list of layouts
+bsp-layout previous --layouts tall,monocle,wide
 
 # For a specific desktop
-bsp-layout cycle --layouts tall,monocle,wide --desktop 4
+bsp-layout previous --layouts tall,monocle,wide --desktop 4
+```
+
+* Go through layouts
+Go through all (or a custom list of) layouts.
+```bash
+# Switch to next layout
+bsp-layout next
+
+# Or to go through a custom list of layouts
+bsp-layout next --layouts tall,monocle,wide
+
+# For a specific desktop
+bsp-layout next --layouts tall,monocle,wide --desktop 4
 ```
 
 * Toggle layout
 ```bash
 # Toggle between monocle and tall layouts
-bsp-layout cycle tall,monocle
+bsp-layout next tall,monocle
 ```
 
 

--- a/bsp-layout.1
+++ b/bsp-layout.1
@@ -6,7 +6,7 @@ bsp-layout \- A dynamic layout manager for bspwm
 
 .SH SYNOPSIS
 .B bsp-layout
-.RB [set|once|get|cycle|remove|layouts|reload|version|help]
+.RB [set|once|get|previous|next|remove|layouts|reload|version|help]
 
 
 
@@ -32,9 +32,15 @@ in the desktop once and changes will not re-calculate layout. If desktop_name
 is not passed, it will apply layout to the currently focused desktop
 
 .TP
-.B cycle <layout> [--layouts tall,wide] [--desktop <desktop_name>]
-Cycle through a list of layouts. If layouts is not passed, the program will
-cycle through all available layouts. If desktop is not passed, it will apply
+.B previous <layout> [--layouts tall,wide] [--desktop <desktop_name>]
+Switch to the previous in a list of layouts. If layouts is not passed, the program will
+go through all available layouts. If desktop is not passed, it will apply
+layout to the currently focused desktop
+
+.TP
+.B next <layout> [--layouts tall,wide] [--desktop <desktop_name>]
+Switch to the next in a list of layouts. If layouts is not passed, the program will
+go through all available layouts. If desktop is not passed, it will apply
 layout to the currently focused desktop
 
 .TP

--- a/src/layout.sh
+++ b/src/layout.sh
@@ -53,7 +53,37 @@ list_layouts() {
   echo -e "$BSP_DEFAULT_LAYOUTS"; ls "$LAYOUTS" | sed -e 's/\.sh$//';
 }
 
-cycle_layouts() {
+previous_layout() {
+  local layouts=$(list_layouts);
+  local desktop_selector=$(get_focused_desktop);
+  while [[ $# != 0 ]]; do
+    case $1 in
+      --layouts)
+          if [[ ! -z "$2" ]]; then
+            layouts=$(echo "$2" | tr ',' '\n');
+          fi;
+          shift;
+      ;;
+      --desktop)
+        desktop_selector="$2";
+        shift;
+      ;;
+      *) ;;
+    esac;
+    shift;
+  done;
+
+  local current_layout=$(get_layout "$desktop_selector");
+  local previous_layout=$(echo -e "$layouts" | grep -x "$current_layout" -B 1 | head -n 1);
+  if [[ "$previous_layout" == "$current_layout" ]] || [[ -z "$previous_layout" ]]; then
+    previous_layout=$(echo -e "$layouts" | head -n 1);
+  fi;
+
+  echo "$current_layout:$previous_layout";
+  start_listener "$previous_layout" "$desktop_selector";
+}
+
+next_layout() {
   local layouts=$(list_layouts);
   local desktop_selector=$(get_focused_desktop);
   while [[ $# != 0 ]]; do
@@ -174,7 +204,8 @@ case "$action" in
   reload)     reload_layouts ;;
   once)       once_layout "$@" ;;
   set)        start_listener "$@" ;;
-  cycle)      cycle_layouts "$@" ;;
+  previous)   previous_layout "$@" ;;
+  next)       next_layout "$@" ;;
   get)        get_layout "$@" ;;
   remove)     remove_listener "$1" ;;
   layouts)    list_layouts ;;


### PR DESCRIPTION
This is a proposed fix for the issue raised in #40.

It was simple enough and IMO this would be useful indeed, as it would enable me to use it in a polybar module for bsp-layouts I'm currently working on.
That way I could use the two directions of the mouse wheel to go back and forth through the list of layouts when hovering over the polybar module.

Let me know if I should combine the functions into one, as I wasn't sure what the more sensible approach would be.