### PR TITLE
Feature: add templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+---
+name: 📝 Bug Report
+description: Report something that isn't working as intended
+labels: ["bug", "needs-triage"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      **Before you proceed, please ensure your issue:**
+
+      - Wasn't already reported on [our issue tracker](https://github.com/phenax/bsp-layout/issues),
+      - Is somewhat reproducible.
+- type: textarea
+  attributes:
+    label: What did you expect to happen?
+    placeholder: When I do X, it should do Y.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What actually happened?
+    description: |
+      - Screenshots, screencasts and gifs are a big help! They can be shared using [asciinema.org](https://asciinema.org) for the terminal or [imgur.com](https://imgur.com) for videos.
+      - **Use [code fences](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) for code, logs, or text dumps!** Or use [pastebin.com](https://pastebin.com)!
+      - Be specific! Phrases like "X does not work" or "X stopped working" are unacceptable.
+    placeholder: |
+      When I do X, Z happened instead of Y.
+
+      And here is the log: https://pastebin.com/fakeurl
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe your attempts to resolve the issue
+    description: |
+      How have you tried to fix your issue? What was the result?
+
+      _(Hint: use [code fences](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) for code or text dumps!)_
+    placeholder: |
+      I tried setting X to Y, then I tried Z. Here's what else I tried...
+
+      ```bash
+      bsp-layout get
+      ```
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: |
+      How do we reproduce your issue? Walk us through a minimal test case.
+
+      > :warning: This is required! If you can't offer steps to reproduce it, it will be hard for us to help you...
+    placeholder: |
+      1. Open a terminal
+      2. Open a few windows on a different desktop
+      3. Run `bsp-layout once even`
+      4. My computer explodes
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: System Information
+    placeholder: |
+      ```bash
+      $ bsp-layout version
+      0.0.10-1
+      ```
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: |
+      :heart: **Thank you for taking the time to file this bug report!**

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,7 +59,18 @@ body:
 - type: textarea
   attributes:
     label: System Information
+    description: |
+      Please give us a bit more information about the system you are using and the version of `bsp-layout` you are running.
+
+      Do you use bsp-layout or bsp-layout-git from the AUR? Did you install it with nixpkgs, make install or the install.sh script?
     placeholder: |
+      I installed the `bsp-layout` command with `sudo make PREFIX=/usr/ install`.
+
+      ```bash
+      $ uname -osrm
+      Linux 5.18.5-arch1-1 x86_64 GNU/Linux
+      ```
+
       ```bash
       $ bsp-layout version
       0.0.10-1

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+---
+name: 📝 Feature Request
+description: Propose a new idea or feature
+labels: ["feature", "needs-triage"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      **Before you proceed, please ensure your request:**
+
+      - Is a feature request and not a bug report,
+      - Hasn't already been requested or reported on [our issue tracker](https://github.com/phenax/bsp-layout/issues),
+      - Hasn't already been fulfilled in latest versions of bsp-layout.
+- type: textarea
+  attributes:
+    label: Describe your request
+    placeholder: |
+      I'd like bsp-layout to send notifications when switching from layout to layout.
+
+      This would give some visual and maybe even auditive feedback when running bsp-layout on key bindings.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Briefly explain its use-case
+    description: |
+      How would your requested feature be used? Can you demonstrate it with a screencast or a visual document?
+    placeholder: |
+      1. Install Linux
+      2. Install bspwm
+      3. Install bsp-layout
+      4. Run `bsp-layout {once,set} {desktop}`
+      5. Get a notification
+      6. Ponder why my machine just exploded
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: |
+      :heart: **Thank you for taking the time to make this feature request!**

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,12 +26,9 @@ body:
     description: |
       How would your requested feature be used? Can you demonstrate it with a screencast or a visual document?
     placeholder: |
-      1. Install Linux
-      2. Install bspwm
-      3. Install bsp-layout
-      4. Run `bsp-layout {once,set} {desktop}`
-      5. Get a notification
-      6. Ponder why my machine just exploded
+      1. Install bsp-layout
+      2. Run `bsp-layout set even {desktop}`
+      3. Get a notification saying "Desktop {desktop} now set to the even layout"
   validations:
     required: true
 - type: markdown


### PR DESCRIPTION
This PR addesses #51.

I've been greatly inspired by the [issue tracker](https://github.com/doomemacs/doomemacs/issues/new/choose) of [doomemacs](https://github.com/doomemacs/doomemacs/tree/master/.github/ISSUE_TEMPLATE) and simplified it a great deal.

In the current form of the templates, (1) a feature label should have to be created or (2) the label in the template can be changed to the default `enhancement` or (3) the `enhancement` label could be changed to `feature` in the label edition panel.
you tell me :+1: 