### PR TITLE
56: complete the documentation in the code base

### DIFF
--- a/src/layout.sh
+++ b/src/layout.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+# global compilation variables that are set with `make`.
 export VERSION="{{VERSION}}";
 export ROOT="{{SOURCE_PATH}}";
 
+# source the lib's tool functions.
 source "$ROOT/utils/desktop.sh";
 source "$ROOT/utils/layout.sh";
 source "$ROOT/utils/state.sh";
@@ -12,15 +14,33 @@ export LAYOUTS="$ROOT/layouts";
 # Layouts provided by bsp out of the box
 BSP_DEFAULT_LAYOUTS="tiled\nmonocle";
 
-# Kill old layout process
+# str -> ::
 kill_layout() {
+  # Kill an old layout process.
+  #
+  # Args:
+  #   $1: the name of the layout.
+  #
+  # Returns:
+  #   ()
+  #
   old_pid="$(get_desktop_options "$1" | valueof pid)";
   kill $old_pid 2> /dev/null || true;
 }
 
+# [str] -> ::
 remove_listener() {
-  desktop=$1;
-  [[ -z "$desktop" ]] && desktop=$(get_focused_desktop);
+  # Remove the listener on the requested desktop.
+  #
+  # Args:
+  #   $1, optional: the name of the desktop. if not provided, defaults to the current
+  #     desktop.
+  #
+  # Returns:
+  #  ()
+  #
+  local desktop=$1;
+  desktop="${desktop:-`get_focused_desktop`}";
 
   kill_layout "$desktop";
 
@@ -29,34 +49,98 @@ remove_listener() {
   set_desktop_option $desktop 'pid'    "";
 }
 
+# str -> str
 get_layout_file() {
+  # Get the source file for given layout.
+  #
+  # Args:
+  #   $1: the name of the layout.
+  #
+  # Returns:
+  #   layout_file: the path to the source file of the layout.
+  #
   local layout_file="$LAYOUTS/$1.sh"; shift;
   # GUARD: Check if layout exists
   [[ ! -f $layout_file ]] && echo "Layout [$layout_file] does not exist" && exit 1;
   echo "$layout_file";
 }
 
-setup_layout() { bash "$(get_layout_file $1)" setup $*; }
+# (str, List[str]) -> ::
+setup_layout() {
+  # Setup the layout.
+  #
+  # Get the name of the layout file and run the setup function on it.
+  #
+  # Args:
+  #   $1: the name of the layout.
+  #
+  # Returns:
+  #   ()
+  #
+  bash "$(get_layout_file $1)" setup $*;
+}
+
+# (str, List[str]) -> ::
 run_layout() {
+  # Run the layout.
+  #
+  # Get the name of the layout file and run the run function on it.
+  #
+  # Args:
+  #   $1: the name of the layout.
+  #
+  # Returns:
+  #   ()
+  #
   local old_scheme=$(bspc config automatic_scheme);
   bspc config automatic_scheme alternate;
   bash "$(get_layout_file $1)" run $*;
   bspc config automatic_scheme $old_scheme;
 }
 
+# [str] -> str
 get_layout() {
+  # Get the layout of the requested desktop.
+  #
+  # Args:
+  #   $1, optional: the name of the desktop. if not provided, defaults to the current
+  #     desktop.
+  #
+  # Returns:
+  #   layout: the name of the layout for the requested desktop.
+  #
   # Set desktop to currently focused desktop if option is not specified
-  local desktop="${1:-`get_focused_desktop`}";
+  local desktop=$1
+  desktop="${desktop:-`get_focused_desktop`}";
 
   local layout=$(get_desktop_options "$desktop" | valueof layout);
   echo "${layout:-"-"}";
 }
 
+# :: -> List[str]
 list_layouts() {
-  echo -e "$BSP_DEFAULT_LAYOUTS"; ls "$LAYOUTS" | sed -e 's/\.sh$//';
+  # List all available layouts in bsp-layout.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   layouts: the list of all the available layouts, one per line.
+  #
+  local layouts=$(echo -e "$BSP_DEFAULT_LAYOUTS"; ls "$LAYOUTS" | sed -e 's/\.sh$//')
+  echo -e "$layouts"
 }
 
+# List[str] -> ::
 previous_layout() {
+  # Switch to the previous layout in given list on given desktop.
+  #
+  # Args:
+  #   $@: all the arguments.
+  #
+  # Returns:
+  #   ()
+  #
   local layouts=$(list_layouts);
   local desktop_selector=$(get_focused_desktop);
   while [[ $# != 0 ]]; do
@@ -86,7 +170,16 @@ previous_layout() {
   start_listener "$previous_layout" "$desktop_selector";
 }
 
+# List[str] -> ::
 next_layout() {
+  # Switch to the next layout in given list on given desktop.
+  #
+  # Args:
+  #   $@: all the arguments.
+  #
+  # Returns:
+  #   ()
+  #
   local layouts=$(list_layouts);
   local desktop_selector=$(get_focused_desktop);
   while [[ $# != 0 ]]; do
@@ -116,7 +209,16 @@ next_layout() {
   start_listener "$next_layout" "$desktop_selector";
 }
 
+# List[str] -> ::
 start_listener() {
+  # Start a listener on given desktop.
+  #
+  # Args:
+  #   $@: all the arguments.
+  #
+  # Returns:
+  #   ()
+  #
   layout=$1; shift;
   selected_desktop=$1; shift;
   [[ "$selected_desktop" == "--" ]] && selected_desktop="";
@@ -137,8 +239,30 @@ start_listener() {
     exit 0;
   fi
 
-  __initialize_layout() { setup_layout $layout $args 2> /dev/null || true; }
-  __recalculate_layout() { run_layout $layout $args 2> /dev/null || true; }
+  # :: -> ::
+  __initialize_layout() {
+    # Initialize the layout.
+    #
+    # Args:
+    #   ()
+    #
+    # Returns:
+    #   ()
+    #
+    setup_layout $layout $args 2> /dev/null || true;
+  }
+  # :: -> ::
+  __recalculate_layout() {
+    # Recalculate the layout.
+    #
+    # Args:
+    #   ()
+    #
+    # Returns:
+    #   ()
+    #
+    run_layout $layout $args 2> /dev/null || true;
+  }
 
   # Then listen to node changes and recalculate as required
   bspc subscribe node_{add,remove,transfer} desktop_focus | while read line; do
@@ -184,12 +308,30 @@ start_listener() {
   echo "[$LAYOUT_PID]";
 }
 
+# List[str] -> ::
 once_layout() {
+  # Apply a layout once to a desktop.
+  #
+  # Args:
+  #   $@: all the arguments.
+  #
+  # Returns:
+  #   ()
+  #
   if (echo -e "$BSP_DEFAULT_LAYOUTS" | grep "^$1$"); then exit 0; fi
   local focused_desktop=$(get_focused_desktop);
   local selected_desktop="${2:-$focused_desktop}";
 
+  # List[str] -> ::
   __calculate_layout() {
+    # Calculate the layout.
+    #
+    # Args:
+    #   $@: all the arguments.
+    #
+    # Returns:
+    #   ()
+    #
     setup_layout "$@";
     run_layout "$@";
     run_layout "$@";
@@ -211,31 +353,52 @@ once_layout() {
   fi;
 }
 
+# :: -> ::
 reload_layouts() {
+  # Reload all currently tracked layouts.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   ()
+  #
   list_desktops | while read desktop; do
     layout=$(get_desktop_options "$desktop" | valueof layout);
     [[ ! -z "$layout" ]] && start_listener $layout $desktop;
   done;
 }
 
-# Check for dependencies
-for dep in bc bspc man; do
-  !(which $dep >/dev/null 2>&1) && echo "[Missing dependency] bsp-layout needs $dep installed" && exit 1;
-done;
+# List[str] -> ::
+main () {
+  # Run the whole bsp-layout command, after parsing the subcommand and calling the appropriate function.
+  #
+  # Args:
+  #   args: the list of unparsed arguments. The 'action' should be the first argument.
+  #
+  # Returns:
+  #   ()
+  #
+  # Check for dependencies.
+  for dep in bc bspc man; do
+    !(which $dep >/dev/null 2>&1) && echo "[Missing dependency] bsp-layout needs $dep installed" && exit 1;
+  done;
 
-action=$1; shift;
+  # parse the argument and run the appropriate subcommand.
+  action=$1; shift;
+  case "$action" in
+    reload)            reload_layouts ;;
+    once)              once_layout "$@" ;;
+    set)               start_listener "$@" ;;
+    previous)          previous_layout "$@" ;;
+    next)              next_layout "$@" ;;
+    get)               get_layout "$1" ;;
+    remove)            remove_listener "$1" ;;
+    layouts)           list_layouts ;;
+    -h|--help|help)    man bsp-layout ;;
+    -v|version)        echo "$VERSION" ;;
+    *)                 echo -e "Unknown subcommand. Run bsp-layout help" && exit 1 ;;
+  esac
+}
 
-case "$action" in
-  reload)            reload_layouts ;;
-  once)              once_layout "$@" ;;
-  set)               start_listener "$@" ;;
-  previous)          previous_layout "$@" ;;
-  next)              next_layout "$@" ;;
-  get)               get_layout "$@" ;;
-  remove)            remove_listener "$1" ;;
-  layouts)           list_layouts ;;
-  -h|--help|help)    man bsp-layout ;;
-  -v|version)        echo "$VERSION" ;;
-  *)                 echo -e "Unknown subcommand. Run bsp-layout help" && exit 1 ;;
-esac
-
+main "$@"

--- a/src/layouts/even.sh
+++ b/src/layouts/even.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/layout.sh";
 
+# :: -> ::
 execute_layout() {
+  # Execute the even layout.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   ()
+  #
   auto_balance '@/';
 }
 

--- a/src/layouts/even.sh
+++ b/src/layouts/even.sh
@@ -3,16 +3,8 @@
 # import the lib.
 source "$ROOT/utils/layout.sh";
 
-# :: -> ::
+# ->
 execute_layout() {
-  # Execute the even layout.
-  #
-  # Args:
-  #   ()
-  #
-  # Returns:
-  #   ()
-  #
   auto_balance '@/';
 }
 

--- a/src/layouts/grid.sh
+++ b/src/layouts/grid.sh
@@ -3,30 +3,14 @@
 # import the lib.
 source "$ROOT/utils/layout.sh";
 
-# :: -> ::
+# ->
 setup_layout() {
-  # Setup the grid layout.
-  #
-  # Args:
-  #   ()
-  #
-  # Returns:
-  #   ()
-  #
   rotate '@/' horizontal 90;
   rotate '@/2' vertical 90;
 }
 
-# :: -> ::
+# ->
 execute_layout() {
-  # Execute the grid layout.
-  #
-  # Args:
-  #   ()
-  #
-  # Returns:
-  #   ()
-  #
   local target='first';
 
   for node in $(bspc query -N -n .local.window | sort); do

--- a/src/layouts/grid.sh
+++ b/src/layouts/grid.sh
@@ -1,13 +1,32 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/layout.sh";
 
+# :: -> ::
 setup_layout() {
+  # Setup the grid layout.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   ()
+  #
   rotate '@/' horizontal 90;
   rotate '@/2' vertical 90;
 }
 
+# :: -> ::
 execute_layout() {
+  # Execute the grid layout.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   ()
+  #
   local target='first';
 
   for node in $(bspc query -N -n .local.window | sort); do

--- a/src/layouts/rgrid.sh
+++ b/src/layouts/rgrid.sh
@@ -3,30 +3,14 @@
 # import the lib.
 source "$ROOT/utils/layout.sh";
 
-# :: -> ::
+# ->
 setup_layout() {
-  # Setup the rgrid layout.
-  #
-  # Args:
-  #   ()
-  #
-  # Returns:
-  #   ()
-  #
   rotate '@/' vertical 90;
   rotate '@/2' horizontal 90;
 }
 
-# List[str] -> ::
+# List[str] ->
 execute_layout() {
-  # Execute the rgrid layout.
-  #
-  # Args:
-  #   $@: the list of all the arguments for the layout.
-  #
-  # Returns:
-  #   ()
-  #
   bash "$ROOT/layouts/grid.sh" run $*;
 }
 

--- a/src/layouts/rgrid.sh
+++ b/src/layouts/rgrid.sh
@@ -1,13 +1,32 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/layout.sh";
 
+# :: -> ::
 setup_layout() {
+  # Setup the rgrid layout.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   ()
+  #
   rotate '@/' vertical 90;
   rotate '@/2' horizontal 90;
 }
 
+# List[str] -> ::
 execute_layout() {
+  # Execute the rgrid layout.
+  #
+  # Args:
+  #   $@: the list of all the arguments for the layout.
+  #
+  # Returns:
+  #   ()
+  #
   bash "$ROOT/layouts/grid.sh" run $*;
 }
 

--- a/src/layouts/rtall.sh
+++ b/src/layouts/rtall.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/common.sh";
 source "$ROOT/utils/layout.sh";
 source "$ROOT/utils/config.sh";
@@ -8,7 +9,16 @@ master_size=$TALL_RATIO;
 
 node_filter="!hidden";
 
+# List[str] -> ::
 execute_layout() {
+  # Execute the rtall layout.
+  #
+  # Args:
+  #   $@: the list of required arguments for the layout.
+  #
+  # Returns:
+  #   ()
+  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/rtall.sh
+++ b/src/layouts/rtall.sh
@@ -9,16 +9,8 @@ master_size=$TALL_RATIO;
 
 node_filter="!hidden";
 
-# List[str] -> ::
+# List[str] ->
 execute_layout() {
-  # Execute the rtall layout.
-  #
-  # Args:
-  #   $@: the list of required arguments for the layout.
-  #
-  # Returns:
-  #   ()
-  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/rwide.sh
+++ b/src/layouts/rwide.sh
@@ -9,16 +9,8 @@ master_size=$WIDE_RATIO;
 
 node_filter="!hidden";
 
-# List[str] -> ::
+# List[str] ->
 execute_layout() {
-  # Execute the rwide layout.
-  #
-  # Args:
-  #   $@: the list of arguments needed by the layout.
-  #
-  # Returns:
-  #   ()
-  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/rwide.sh
+++ b/src/layouts/rwide.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/common.sh";
 source "$ROOT/utils/layout.sh";
 source "$ROOT/utils/config.sh";
@@ -8,7 +9,16 @@ master_size=$WIDE_RATIO;
 
 node_filter="!hidden";
 
+# List[str] -> ::
 execute_layout() {
+  # Execute the rwide layout.
+  #
+  # Args:
+  #   $@: the list of arguments needed by the layout.
+  #
+  # Returns:
+  #   ()
+  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/tall.sh
+++ b/src/layouts/tall.sh
@@ -9,16 +9,8 @@ master_size=$TALL_RATIO;
 
 node_filter="!hidden";
 
-# List[str] -> :;
+# List[str] ->
 execute_layout() {
-  # Execute the rall layout.
-  #
-  # Args:
-  #   $@: the list of arguments required by the layout.
-  #
-  # Returns:
-  #   ()
-  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/tall.sh
+++ b/src/layouts/tall.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/common.sh";
 source "$ROOT/utils/layout.sh";
 source "$ROOT/utils/config.sh";
@@ -8,7 +9,16 @@ master_size=$TALL_RATIO;
 
 node_filter="!hidden";
 
+# List[str] -> :;
 execute_layout() {
+  # Execute the rall layout.
+  #
+  # Args:
+  #   $@: the list of arguments required by the layout.
+  #
+  # Returns:
+  #   ()
+  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/wide.sh
+++ b/src/layouts/wide.sh
@@ -9,16 +9,8 @@ master_size=$WIDE_RATIO;
 
 node_filter="!hidden";
 
-# List[str] -> ::
+# List[str] ->
 execute_layout() {
-  # Execute the wide layout.
-  #
-  # Args:
-  #   $@: the list of arguments required by the layout.
-  #
-  # Returns:
-  #   ()
-  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/layouts/wide.sh
+++ b/src/layouts/wide.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# import the lib.
 source "$ROOT/utils/common.sh";
 source "$ROOT/utils/layout.sh";
 source "$ROOT/utils/config.sh";
@@ -8,7 +9,16 @@ master_size=$WIDE_RATIO;
 
 node_filter="!hidden";
 
+# List[str] -> ::
 execute_layout() {
+  # Execute the wide layout.
+  #
+  # Args:
+  #   $@: the list of arguments required by the layout.
+  #
+  # Returns:
+  #   ()
+  #
   while [[ ! "$#" == 0 ]]; do
     case "$1" in
       --master-size) master_size="$2"; shift; ;;

--- a/src/utils/common.sh
+++ b/src/utils/common.sh
@@ -1,9 +1,9 @@
 # str -> str
 jget() {
     # TODO.
-    key=$1
-    shift
-    var=${*#*\"$key\":}
-    var=${var%%[,\}]*}
-    echo "$var"
+    key=$1;
+    shift;
+    var=${*#*\"$key\":};
+    var=${var%%[,\}]*};
+    echo "$var";
 }

--- a/src/utils/common.sh
+++ b/src/utils/common.sh
@@ -1,4 +1,6 @@
+# str -> str
 jget() {
+    # TODO.
     key=$1
     shift
     var=${*#*\"$key\":}

--- a/src/utils/config.sh
+++ b/src/utils/config.sh
@@ -1,9 +1,13 @@
+# this module extracts the user config.
+
+# get the name of the config file.
 XDG_CONF=${XDG_CONFIG_DIR:-"$HOME/.config"};
 CONFIG_DIR="$XDG_CONF/bsp-layout";
 
-# Default config
+# Default config.
 export TALL_RATIO=0.6;
 export WIDE_RATIO=0.6;
 export USE_NAMES=1;
 
+# extract the actual user config.
 source "$CONFIG_DIR/layoutrc" 2> /dev/null || true;

--- a/src/utils/desktop.sh
+++ b/src/utils/desktop.sh
@@ -4,27 +4,15 @@ source "$ROOT/utils/config.sh";
 names="--names"
 [[ $USE_NAMES -eq 0 ]] && names="";
 
-# :: -> str
+# -> str
 get_focused_desktop() {
-  # Get the name of the focused desktop.
-  #
-  # Args:
-  #   ()
-  #
-  # Returns:
-  #   desktop: the name of the focused desktop.
-  #
-    bspc query -D -d 'focused' $names;
+    local desktop=$(bspc query -D -d 'focused' $names);
+    echo "$desktop";
 }
 
 # int -> str
 get_desktop_name_from_id() {
-  # Get the name of the desktop whose ID is the one given as argument.
-  #
-  # Args:
-  #   $1: the id of the desktop.
-  #
-  # Returns:
-  #   desktop_name: the name of the desktop.
-    bspc query -D -d "$1" $names;
+    local id=$1;
+    local desktop_name=$(bspc query -D -d "$id" $names);
+    echo "$desktop_name";
 }

--- a/src/utils/desktop.sh
+++ b/src/utils/desktop.sh
@@ -1,6 +1,30 @@
+# import the lib.
 source "$ROOT/utils/config.sh";
+
 names="--names"
 [[ $USE_NAMES -eq 0 ]] && names="";
-get_focused_desktop() { bspc query -D -d 'focused' $names; }
-get_desktop_name_from_id() { bspc query -D -d "$1" $names; }
 
+# :: -> str
+get_focused_desktop() {
+  # Get the name of the focused desktop.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   desktop: the name of the focused desktop.
+  #
+    bspc query -D -d 'focused' $names;
+}
+
+# int -> str
+get_desktop_name_from_id() {
+  # Get the name of the desktop whose ID is the one given as argument.
+  #
+  # Args:
+  #   $1: the id of the desktop.
+  #
+  # Returns:
+  #   desktop_name: the name of the desktop.
+    bspc query -D -d "$1" $names;
+}

--- a/src/utils/layout.sh
+++ b/src/utils/layout.sh
@@ -1,18 +1,9 @@
 # import the lib.
 source "$ROOT/utils/common.sh";
 
-# (str, str, int) -> ::
+# (str, str, int) ->
 rotate() {
-  # Amend the split type so we are arranged correctly
-  #
-  # Args:
-  #   $1: the node to apply the rotation to.
-  #   $2: the orientation that we want.
-  #   $3: the angle of rotation.
-  #
-  # Returns:
-  #   ()
-  #
+  # Amend the split type so we are arranged correctly.
   node=$1;
   want=$2;
   have=$(jget splitType "$(bspc query -T -n "$node")");
@@ -24,15 +15,9 @@ rotate() {
   fi
 }
 
-# str -> ::
+# str ->
 auto_balance() {
   # Balance the tree rooted at some node automatically.
-  #
-  # Args:
-  #   $1: the root node to balance the tree.
-  #
-  # Returns:
-  #   ()
-  #
-  bspc node "$1" -B;
+  local node=$1;
+  bspc node "$node" -B;
 }

--- a/src/utils/layout.sh
+++ b/src/utils/layout.sh
@@ -1,7 +1,18 @@
+# import the lib.
 source "$ROOT/utils/common.sh";
 
-# amend the split type so we are arranged correctly
+# (str, str, int) -> ::
 rotate() {
+  # Amend the split type so we are arranged correctly
+  #
+  # Args:
+  #   $1: the node to apply the rotation to.
+  #   $2: the orientation that we want.
+  #   $3: the angle of rotation.
+  #
+  # Returns:
+  #   ()
+  #
   node=$1;
   want=$2;
   have=$(jget splitType "$(bspc query -T -n "$node")");
@@ -13,4 +24,15 @@ rotate() {
   fi
 }
 
-auto_balance() { bspc node "$1" -B; }
+# str -> ::
+auto_balance() {
+  # Balance the tree rooted at some node automatically.
+  #
+  # Args:
+  #   $1: the root node to balance the tree.
+  #
+  # Returns:
+  #   ()
+  #
+  bspc node "$1" -B;
+}

--- a/src/utils/state.sh
+++ b/src/utils/state.sh
@@ -1,21 +1,77 @@
+# The location where the states of the desktops are stored.
 DESKTOP_STATE="/tmp/bsp-layout.state/desktops";
 
+# NOTE: not sure about the meaning of that signature...
 # (Data ->) :: Key -> Value -> Data
-append_option() { sed "/^$1:/d"; echo "$1:$2"; }
+append_option() {
+  # Append an option to a list of options.
+  #
+  # Args:
+  #   $1: the key of the new option.
+  #   $2: the value of the new option.
+  #
+  # Returns:
+  #   data: the new data with the option inserted.
+  #
+  sed "/^$1:/d"; echo "$1:$2";
+}
 
+# NOTE: not sure about the meaning of that signature...
 # (Data ->) :: Key -> Data[Key]
-valueof() { awk -F':' "/^$1:/ {print \$2}"; }
+valueof() {
+  # Get the value of some data indexed by a key.
+  #
+  # Args:
+  #   $1: the key to get the value from.
+  #
+  # Returns:
+  #   value: the actual value indexed by the key.
+  #
+  awk -F':' "/^$1:/ {print \$2}";
+}
 
+# NOTE: not sure about the meaning of that signature...
 # :: DesktopName -> Data
-get_desktop_options() { cat "$DESKTOP_STATE/$1" 2> /dev/null || true; }
+get_desktop_options() {
+  # Get the current options for a given desktop.
+  #
+  # Args:
+  #   $1: the name of the desktop.
+  #
+  # Returns:
+  #   options: the current options set for the desktop.
+  #
+  cat "$DESKTOP_STATE/$1" 2> /dev/null || true;
+}
 
+# NOTE: not sure about the meaning of that signature...
 # :: DesktopName -> Key -> Value -> ()
 set_desktop_option() {
+  # Set a new option for a desktop.
+  #
+  # Args:
+  #   $1: the name of the desktop.
+  #   $2: the key, i.e. the name of the option.
+  #   $3: the value of the option to set.
+  #
+  # Returns:
+  #   ()
+  #
   new_options=$(get_desktop_options "$1" | append_option $2 $3);
   mkdir -p "$DESKTOP_STATE";
   echo "$new_options" > "$DESKTOP_STATE/$1";
 }
 
-# :: List[DesktopName]
-list_desktops() { ls -1 "$DESKTOP_STATE"; }
-
+# NOTE: not sure about the meaning of that signature...
+# :: List[str]
+list_desktops() {
+  # Give the list of desktops bsp-layout is listening to.
+  #
+  # Args:
+  #   ()
+  #
+  # Returns:
+  #   desktops: the list of desktop names which are tracked by bsp-layout.
+  #
+  ls -1 "$DESKTOP_STATE";
+}

--- a/src/utils/state.sh
+++ b/src/utils/state.sh
@@ -1,77 +1,37 @@
 # The location where the states of the desktops are stored.
 DESKTOP_STATE="/tmp/bsp-layout.state/desktops";
 
-# NOTE: not sure about the meaning of that signature...
-# (Data ->) :: Key -> Value -> Data
+# (|Dict[str, str]|, str, str) -> Dict(str)
 append_option() {
-  # Append an option to a list of options.
-  #
-  # Args:
-  #   $1: the key of the new option.
-  #   $2: the value of the new option.
-  #
-  # Returns:
-  #   data: the new data with the option inserted.
-  #
-  sed "/^$1:/d"; echo "$1:$2";
+  local key=$1;
+  local value=$2;
+  sed "/^$key:/d"; echo "$key:$value";
 }
 
-# NOTE: not sure about the meaning of that signature...
-# (Data ->) :: Key -> Data[Key]
-valueof() {
-  # Get the value of some data indexed by a key.
-  #
-  # Args:
-  #   $1: the key to get the value from.
-  #
-  # Returns:
-  #   value: the actual value indexed by the key.
-  #
-  awk -F':' "/^$1:/ {print \$2}";
+# (|Dict[str, str]|, str) -> str
+get_value_of() {
+  local key=$1;
+  awk -F':' "/^$key:/ {print \$2}";
 }
 
-# NOTE: not sure about the meaning of that signature...
-# :: DesktopName -> Data
+# str -> List[str]
 get_desktop_options() {
-  # Get the current options for a given desktop.
-  #
-  # Args:
-  #   $1: the name of the desktop.
-  #
-  # Returns:
-  #   options: the current options set for the desktop.
-  #
-  cat "$DESKTOP_STATE/$1" 2> /dev/null || true;
+  local desktop=$1;
+  cat "$DESKTOP_STATE/$desktop" 2> /dev/null || true;
 }
 
-# NOTE: not sure about the meaning of that signature...
-# :: DesktopName -> Key -> Value -> ()
+# (str, str, str) ->
 set_desktop_option() {
-  # Set a new option for a desktop.
-  #
-  # Args:
-  #   $1: the name of the desktop.
-  #   $2: the key, i.e. the name of the option.
-  #   $3: the value of the option to set.
-  #
-  # Returns:
-  #   ()
-  #
-  new_options=$(get_desktop_options "$1" | append_option $2 $3);
+  local desktop=$1;
+  local key=$2;
+  local value=$3;
+  new_options=$(get_desktop_options "$desktop" | append_option $key $value);
   mkdir -p "$DESKTOP_STATE";
-  echo "$new_options" > "$DESKTOP_STATE/$1";
+  echo "$new_options" > "$DESKTOP_STATE/$desktop";
 }
 
-# NOTE: not sure about the meaning of that signature...
-# :: List[str]
+# -> List[str]
 list_desktops() {
-  # Give the list of desktops bsp-layout is listening to.
-  #
-  # Args:
-  #   ()
-  #
-  # Returns:
-  #   desktops: the list of desktop names which are tracked by bsp-layout.
-  #
-  ls -1 "$DESKTOP_STATE";
+  local desktops=$(ls -1 "$DESKTOP_STATE");
+  echo -e "$desktops";
 }


### PR DESCRIPTION
Addresses issue #56.

In this PR, i have tried to:
  - add function signatures where it was missing
  - change some of the signatures to make them more coherent across the code base
  - rename some functions to make their use clearer and remove their documentation, now not necessary anymore
  - add "_;_" at the end of the lines where i noticed it was missing
  - put the main code of `./src/layout.sh` in its own `main` function

The convention for the signatures is quite `python`-like:
  - `str` and `int` as the main "_types_"
  - `List[{type}]` for an unknown number of arguments
  - `Dict[{key_type}, {value_type}]` for an associative array
  - `[{type}]` for an optional type
  - `({type_1}, {type_2})` when there are multiple inputs / outputs
  - `->` to link the inputs and the outputs
  - nothing before, resp. after, the `->` when there is not input, resp. output, values
  - and i've also added, for the functions that are used after a pipe (`|`), `|{piped_type}|` to indicate argument comes from a pipe