### PR TITLE
Fix cycling issue for `previous` command

### DIFF
--- a/src/layout.sh
+++ b/src/layout.sh
@@ -76,7 +76,7 @@ previous_layout() {
   local current_layout=$(get_layout "$desktop_selector");
   local previous_layout=$(echo -e "$layouts" | grep -x "$current_layout" -B 1 | head -n 1);
   if [[ "$previous_layout" == "$current_layout" ]] || [[ -z "$previous_layout" ]]; then
-    previous_layout=$(echo -e "$layouts" | head -n 1);
+    previous_layout=$(echo -e "$layouts" | tail -n 1);
   fi;
 
   echo "$current_layout:$previous_layout";


### PR DESCRIPTION
With PR #41 I implemented some changes that got merged into master a while ago.

While the added commands `next` and `previous`, seemed to work, I noticed that I made a mistake, which results in the layouts not cycling back to the beginning of the layout list, when using the `previous` command. The previous (last in the list) layout is not returned after running `previous` with the layout being the first in the list of layouts and results in the layout not changing.

This PR fixes the issue at hand.

I noticed these issues while working on a bsp-layout-switcher module for polybar.
For anyone interested I will add a few tidbits about the polybar module below:

<details>
<summary>Details polybar module </summary>

This is the module configuration that has to be added to polybars user modules in `~/.config/polybar/user_modules.ini`:

```ini
[module/bsp-layout-switcher]
type = custom/script
exec = ~/.config/polybar/polybar-scripts/bsp-layout-switcher.sh
scroll-up =~/.config/polybar/polybar-scripts/bsp-layout-switcher.sh --previous &
scroll-down = ~/.config/polybar/polybar-scripts/bsp-layout-switcher.sh --next &
click-left = ~/.config/polybar/polybar-scripts/bsp-layout-switcher.sh --reload &
click-right = ~/.config/polybar/polybar-scripts/bsp-layout-switcher.sh --remove &
interval = 1
```

The script itself can be placed anywhere, but the module uses the path `~/.config/polybar/polybar-scripts/bsp-layout-switcher.sh`, so make sure to adapt it if you place the script somewhere else:
```sh
#!/bin/sh

FOCUSED_DESKTOP=$(bspc query -D -d 'focused' --names)

case "$1" in
    --previous)
        bsp-layout previous ${FOCUSED_DESKTOP}
        ;;
    --next)
        bsp-layout next ${FOCUSED_DESKTOP}
        ;;
    --reload)
        bsp-layout reload ${FOCUSED_DESKTOP}
        ;;
    --remove)
        bsp-layout remove ${FOCUSED_DESKTOP}
        ;;
    *)
        bsp-layout get ${FOCUSED_DESKTOP}
        ;;
esac
```

Please let me know if I should add this to the README or any other relevant documentation, as I'm unsure how many people will benefit from it besides myself.

</details>