### PR TITLE
Simplify install: contract multiple cp and sed commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ install:
 	mkdir -p ${BINARY_PATH} ${SRC_PATH} ${MAN_PATH}
 	cp -rf src/* ${SRC_PATH}/ # Source files
 	# Update version and source path
-	cp src/layout.sh layout.sh.tmp
-	sed "s|{{VERSION}}|${VERSION}|g" -i layout.sh.tmp
-	sed "s|{{SOURCE_PATH}}|${SRC_PATH}|g" -i layout.sh.tmp
-	cp -f layout.sh.tmp ${SRC_PATH}/layout.sh
-	rm layout.sh.tmp
+	sed -e "s|{{VERSION}}|${VERSION}|g" -e "s|{{SOURCE_PATH}}|${SRC_PATH}|g" src/layout.sh >${SRC_PATH}/layout.sh
 	sed "s|{{VERSION}}|${VERSION}|g" bsp-layout.1 > "${MANPAGE}"
 	# Permissions
 	chmod 644 ${MANPAGE} # Manpage permission


### PR DESCRIPTION
This doesn't fix anything, only simplifies the install process.
This commit avoids multiple commands, where one is sufficient.