### PR TITLE
remove bc from the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Manage layouts in bspwm (tall and wide)
 ### Dependencies
 * `bash`
 * `bspc`
-* `bc`
 * `man`
 
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ VERSION=$(git describe --tags --abbrev=0)
 sudo make VERSION="$VERSION" install || exit 1
 
 # Check for dependencies
-for dep in bc bspc bash man; do
+for dep in bspc bash man; do
   !(which $dep >/dev/null 2>&1) && echo "[Missing dependency] bsp-layout needs $dep installed"
 done
 

--- a/src/utils/common.sh
+++ b/src/utils/common.sh
@@ -10,7 +10,7 @@ jget() {
 
 # () -> ()
 check_dependencies () {
-  for dep in bc bspc man; do
+  for dep in bspc man; do
     !(which $dep >/dev/null 2>&1) && {
       echo "[Missing dependency] bsp-layout needs $dep installed"
       exit 1


### PR DESCRIPTION
Should close #70.

As `bc` is not used anywhere in the code, this PR removes it from the dependencies of `bsp-layout`.

## before the PR
`bc` is only used in the dependency checks but never as an actual command call
```bash
> rg -w bc
install.sh:for dep in bc bspc bash man; do
README.md:* `bc`
src/utils/common.sh:  for dep in bc bspc man; do
```

## after the PR
`rg -w bc` is empty :ok_hand: 